### PR TITLE
Add mime types to nginx.conf

### DIFF
--- a/charts/ui-plugin-server/Chart.yaml
+++ b/charts/ui-plugin-server/Chart.yaml
@@ -1,6 +1,6 @@
 annotations:
   catalog.cattle.io/certified: rancher # Any application we are adding as a helm chart
-  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.25.0-0'
+  catalog.cattle.io/kube-version: '>= 1.16.0-0 < 1.26.0-0'
   catalog.cattle.io/namespace: cattle-ui-plugin-system # Must prefix with cattle- and suffix with -system=
   catalog.cattle.io/os: linux
   catalog.cattle.io/permits-os: linux, windows

--- a/package/nginx.conf
+++ b/package/nginx.conf
@@ -1,5 +1,6 @@
 events {}
 http {
+    include /etc/nginx/mime.types;
     sendfile on;
     server {
         listen 8080;


### PR DESCRIPTION
This adds the mime types to the nginx.conf that gets inserted into the extension container image.

For an air-gapped installation we can run the container image from a private registry, but in order to pull the files within Rancher the mime type needs to be set correctly or there will be a mismatch.

Also bumps the Kubernetes max version for extensions to allow for less than `1.26.0` to account for Rancher `v2.7.2` defaults.